### PR TITLE
Refactored to not use each in loop and removed extra testing deps

### DIFF
--- a/lib/Locale/US/CensusDivisions.pm
+++ b/lib/Locale/US/CensusDivisions.pm
@@ -54,13 +54,15 @@ Daniel Culver, C<< perlsufi@cpan.org >>
 
 Wikipedia L<Census Bureau Divisions|https://en.wikipedia.org/wiki/List_of_regions_of_the_United_States#Census_Bureau-designated_regions_and_divisions>
 
-HostGator
+L<HostGator|http://www.hostgator.com>
 
 =head1 CONTRIBUTORS
 
 William Seymour
 
 Doug Schrag
+
+Robert Stone
 
 =head1 LICENSE AND COPYRIGHT
 
@@ -84,10 +86,9 @@ sub state2division {
     my $code = shift
       || croak 'state2division requires a state abbreviation string';
 
-    while ( my ( $key, $value ) = each %divisions ) {
-        if ( ( grep { $code eq $_ } @$value ) ) {
-            keys %divisions;    # reset the iterator
-            return $key;
+    for my $division ( keys %divisions ) {
+        if ( grep { $code eq $_ } @{ $divisions{$division} } ) {
+            return $division;
         }
     }
 

--- a/t/01-state2division.t
+++ b/t/01-state2division.t
@@ -3,7 +3,8 @@
 use strict;
 use warnings;
 
-use Test::Most;
+use Test::More;
+use Test::Exception;
 use Locale::US::CensusDivisions qw(state2division);
 
 my @state_list = qw( AL AK AZ AR CA CO CT DC DE FL GA HI ID IL IN IA KS KY LA ME
@@ -32,7 +33,6 @@ subtest "Check if TX is division 7" => sub {
 };
 
 subtest "Bad state code croaks with error" => sub {
-
     my $state = 'FA';
 
     throws_ok {


### PR DESCRIPTION
In Locale::US::CensusDivisions
  Rather than using each and then having to "reset the iterator" just
  use for with keys
    The test coverage showed that the old approach worked, but it is a
    bit of a code smell.

In t/01-state2division.t
  Removed extra testing deps brought in by Test::Most, only need
  Test::More and Test::Exception
